### PR TITLE
Update date functions for IL_Ver_A_PluggingReport and IL_InspectorCasingCement_B

### DIFF
--- a/src/ogrre_data_cleaning/processor_schemas/isgs_extractors/IL_InspectorCasingCement_B.json
+++ b/src/ogrre_data_cleaning/processor_schemas/isgs_extractors/IL_InspectorCasingCement_B.json
@@ -1554,7 +1554,7 @@
         "occurrence": "Optional once",
         "grouping": null,
         "database_data_type": "date",
-        "cleaning_function": "string_to_date",
+        "cleaning_function": "clean_date",
         "accepted_range": null,
         "field_specific_notes": null,
         "model_enabled": "Yes"
@@ -1658,7 +1658,7 @@
         "occurrence": "Optional once",
         "grouping": null,
         "database_data_type": "date",
-        "cleaning_function": "string_to_date",
+        "cleaning_function": "clean_date",
         "accepted_range": null,
         "field_specific_notes": null,
         "model_enabled": "No"

--- a/src/ogrre_data_cleaning/processor_schemas/isgs_extractors/IL_Ver_A_PluggingReport.json
+++ b/src/ogrre_data_cleaning/processor_schemas/isgs_extractors/IL_Ver_A_PluggingReport.json
@@ -546,7 +546,7 @@
         "occurrence": "Optional once",
         "grouping": null,
         "database_data_type": "date",
-        "cleaning_function": "string_to_date",
+        "cleaning_function": "clean_date",
         "accepted_range": null,
         "field_specific_notes": null,
         "model_enabled": "Yes"
@@ -618,7 +618,7 @@
         "occurrence": "Optional once",
         "grouping": null,
         "database_data_type": "date",
-        "cleaning_function": "string_to_date",
+        "cleaning_function": "clean_date",
         "accepted_range": null,
         "field_specific_notes": null,
         "model_enabled": "Yes"
@@ -642,7 +642,7 @@
         "occurrence": "Optional once",
         "grouping": null,
         "database_data_type": "date",
-        "cleaning_function": "string_to_date",
+        "cleaning_function": "clean_date",
         "accepted_range": null,
         "field_specific_notes": null,
         "model_enabled": "Yes"
@@ -690,7 +690,7 @@
         "occurrence": "Optional once",
         "grouping": null,
         "database_data_type": "date",
-        "cleaning_function": "string_to_date",
+        "cleaning_function": "clean_date",
         "accepted_range": null,
         "field_specific_notes": null,
         "model_enabled": "Yes"
@@ -714,7 +714,7 @@
         "occurrence": "Optional once",
         "grouping": null,
         "database_data_type": "date",
-        "cleaning_function": "string_to_date",
+        "cleaning_function": "clean_date",
         "accepted_range": null,
         "field_specific_notes": null,
         "model_enabled": "Yes"
@@ -1362,7 +1362,7 @@
         "occurrence": "Optional once",
         "grouping": null,
         "database_data_type": "date",
-        "cleaning_function": "string_to_date",
+        "cleaning_function": "clean_date",
         "accepted_range": null,
         "field_specific_notes": null,
         "model_enabled": "Yes"
@@ -1890,7 +1890,7 @@
         "occurrence": "Optional once",
         "grouping": null,
         "database_data_type": "date",
-        "cleaning_function": "string_to_date",
+        "cleaning_function": "clean_date",
         "accepted_range": null,
         "field_specific_notes": null,
         "model_enabled": "Yes"


### PR DESCRIPTION
Change `string_to_date` to `clean_date`.

There are 2 date cleaning functions: `string_to_date` and `clean_date`. Most of the processors use `clean_date`. `string_to_date` doesn't appear to work properly. 