### PR TITLE
Rewrite convert_hole_size_to_decimal() function

### DIFF
--- a/src/ogrre_data_cleaning/clean.py
+++ b/src/ogrre_data_cleaning/clean.py
@@ -5,6 +5,7 @@ import dateutil.parser as date_parser
 import torch
 import numpy as np
 import pandas as pd
+import unicodedata
 
 from ogrre_data_cleaning.models.encoder import Encoder, Classifier
 from ogrre_data_cleaning.models.dataloaders import HoleSize
@@ -435,6 +436,25 @@ def normalize_special_hole_size(size_str):
     
     return size_str
 
+def is_unicode_fraction(m_char):
+    """Checks if a character is a unicode fraction
+    """
+    try:
+        value = unicodedata.numeric(m_char)
+        return not value.is_integer()
+    except:
+        return False
+
+def separate_fractions(m_str):
+    """Adds a space before unicode fractions detected to avoid cases like "17½" -> 171/2 == 85.5
+    """
+    res = []
+    for i, char in enumerate(m_str):
+        if is_unicode_fraction(char):
+            res.append(' ')
+        res.append(char)
+    return ''.join(res)
+
 def convert_hole_size_to_decimal(size_str):
     """Convert hole size string to decimal value."""
     if not size_str or pd.isna(size_str):
@@ -454,8 +474,30 @@ def convert_hole_size_to_decimal(size_str):
     if not size_str:
         return None
     
+    size_str = separate_fractions(size_str)
+    print(f"DEBUG: After separating fractions - size_str = '{size_str}'")
+
     # Replace any Unicode fractions with standard ASCII
-    size_str = size_str.replace('½', '1/2').replace('¼', '1/4').replace('¾', '3/4')
+    common_fracs = {
+        "½": "1/2",
+        "⅓": "1/3",
+        "⅔": "2/3",
+        "¼": "1/4",
+        "¾": "3/4",
+        "⅕": "1/5",
+        "⅖": "2/5",
+        "⅗": "3/5",
+        "⅘": "4/5",
+        "⅙": "1/6",
+        "⅚": "5/6",
+        "⅐": "1/7",
+        "⅛": "1/8",
+        "⅜": "3/8",
+        "⅝": "5/8",
+        "⅞": "7/8" # ⅑, ⅒, ⅟, ↉, 
+    }
+    for m_frac, frac_ascii in common_fracs.items():
+        size_str = size_str.replace(m_frac, frac_ascii)
     print(f"DEBUG: After Unicode replacement - size_str='{size_str}', type={type(size_str)}")
     
     # Remove any remaining whitespace and quotes

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -122,10 +122,15 @@ def test_clean_bool(input_value, expected):
     ("None", None),
     ("N/A", None),
     (8.75, 8.75),
-    # ("5\u00bd", 5.5), # COMMENTED OUT: Pre-existing bug - unicode ½ parsing returns 25.5 instead of 5.5
+    ("5\u00bd", 5.5),
     ("85/8", 8.625),
     ("95/8", 9.625),
     ("133/8", 13.375),
+    ("17½", 17.5),
+    ("5\u215E", 5.875),
+    ("8⅝", 8.625),
+    ("9⅝", 9.625),
+    ("13⅜", 13.375)
     # ("8 3/4\" OD", 8.75),  # COMMENTED OUT: Pre-existing bug - can't handle OD suffix, returns None
 ])
 def test_convert_hole_size_to_decimal(input_value, expected):


### PR DESCRIPTION
The convert_hole_size_to_decimal() function was incorrectly cleaning many instances of hole sizes throughout the OGRRE data and needed to be rewritten. I added a function to space-separate any unicode values before replacing them with ASCII. Additionally, I added many unicode fractions to the list of fractions being converted to ASCII. Tests were added to ensure better use case coverage.